### PR TITLE
Fix depreciation warning with latest AA

### DIFF
--- a/lib/active_admin/state_machine/dsl.rb
+++ b/lib/active_admin/state_machine/dsl.rb
@@ -25,8 +25,8 @@ module ActiveAdmin
         end
 
         http_verb = options.fetch :http_verb, :put
-        
-        action_item only: :show do
+
+        action_item action.to_sym only: :show do
           if resource.send("can_#{action}?") && authorized?(options[:permission], resource)
             path = resource_path << "/#{action}"
             label = I18n.t("#{plural}.#{action}.label", default: action.to_s.titleize)


### PR DESCRIPTION
When tracking master for ActiveAdmin 1.0.0, a deprecation warning is thrown when starting the app:

WARN -- : DEPRECATION WARNING: Active Admin: using `action_item` without a name is deprecated! Use `action_item(:edit)`. (called from action_item at /***/.bundle/ruby/2.1.0/bundler/gems/activeadmin-77adc9d56b41/lib/active_admin/dsl.rb:92)

This PR intends to resolve it.