### PR TITLE
[MASTER] Deprecation Warning

### DIFF
--- a/active_admin-state_machine.gemspec
+++ b/active_admin-state_machine.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.test_files = Dir["spec/**/*"]
 
   s.add_dependency "rails", ">= 3.2"
-  s.add_dependency "activeadmin"
+  s.add_dependency "activeadmin", ">= 1.0.0.pre1"
   s.add_dependency "state_machine"
 
   s.add_development_dependency "rake", "> 10.0"
@@ -30,4 +30,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency "capybara-webkit"
   s.add_development_dependency "database_cleaner"
   s.add_development_dependency "factory_girl_rails"
+  s.add_development_dependency "devise", "~> 3.4"
 end

--- a/lib/active_admin/state_machine/dsl.rb
+++ b/lib/active_admin/state_machine/dsl.rb
@@ -26,7 +26,7 @@ module ActiveAdmin
 
         http_verb = options.fetch :http_verb, :put
         
-        action_item only: :show do
+        action_item 'active_admin', only: :show do
           if resource.send("can_#{action}?") && authorized?(options[:permission], resource)
             path = resource_path << "/#{action}"
             label = I18n.t("#{plural}.#{action}.label", default: action.to_s.titleize)

--- a/lib/active_admin/state_machine/dsl.rb
+++ b/lib/active_admin/state_machine/dsl.rb
@@ -26,7 +26,12 @@ module ActiveAdmin
 
         http_verb = options.fetch :http_verb, :put
 
-        action_item "state_action_#{action}", only: :show do
+        action_item_args = if ActiveAdmin::VERSION.start_with?('0.')
+                             [{ only: :show }]
+                           else
+                             ["state_action_#{action}", { only: :show }]
+                           end
+        action_item(*action_item_args) do
           if resource.send("can_#{action}?") && authorized?(options[:permission], resource)
             path = resource_path << "/#{action}"
             label = I18n.t("#{plural}.#{action}.label", default: action.to_s.titleize)

--- a/lib/active_admin/state_machine/dsl.rb
+++ b/lib/active_admin/state_machine/dsl.rb
@@ -25,8 +25,8 @@ module ActiveAdmin
         end
 
         http_verb = options.fetch :http_verb, :put
-        
-        action_item 'active_admin', only: :show do
+
+        action_item "state_action_#{action}", only: :show do
           if resource.send("can_#{action}?") && authorized?(options[:permission], resource)
             path = resource_path << "/#{action}"
             label = I18n.t("#{plural}.#{action}.label", default: action.to_s.titleize)

--- a/spec/dummy/app/admin/categories.rb
+++ b/spec/dummy/app/admin/categories.rb
@@ -1,5 +1,5 @@
 ActiveAdmin.register Category do
-  action_item only: :show do
+  action_item 'state_action_category', only: :show do
     link_to "Posts", admin_category_posts_path(resource)
   end
 end

--- a/spec/dummy/config/application.rb
+++ b/spec/dummy/config/application.rb
@@ -7,6 +7,7 @@ require "action_mailer/railtie"
 require "active_resource/railtie"
 require "sprockets/railtie"
 # require "rails/test_unit/railtie"
+require "devise"
 
 Bundler.require(*Rails.groups)
 require "active_admin/state_machine"

--- a/spec/dummy/config/initializers/active_admin.rb
+++ b/spec/dummy/config/initializers/active_admin.rb
@@ -100,7 +100,7 @@ ActiveAdmin.setup do |config|
   # Admin comments are enabled by default.
   #
   # Default:
-  config.allow_comments = false
+  config.comments = false
   #
   # You can turn them on and off for any given namespace by using a
   # namespace config block.

--- a/spec/factories/categories.rb
+++ b/spec/factories/categories.rb
@@ -2,7 +2,7 @@ FactoryGirl.define do
   factory :category do
     sequence(:name) { |n| "Category #{n}" }
 
-    ignore do
+    transient do
       num_posts 0
     end
 


### PR DESCRIPTION
DEPRECATION WARNING : Active Admin: using  without a name is deprecated! Use . (called from action_item at ~/.bundler/ruby/2.1.5/active_admin-add0928290f3/lib