### PR TITLE
[MASTER] Fix active admin deprecated in dummy app

### DIFF
--- a/lib/active_admin/state_machine/version.rb
+++ b/lib/active_admin/state_machine/version.rb
@@ -1,5 +1,5 @@
 module ActiveAdmin
   module StateMachine
-    VERSION = "0.1.1"
+    VERSION = "0.1.2"
   end
 end

--- a/spec/dummy/app/admin/categories.rb
+++ b/spec/dummy/app/admin/categories.rb
@@ -1,5 +1,10 @@
 ActiveAdmin.register Category do
-  action_item 'state_action_category', only: :show do
+    action_item_args =  if ActiveAdmin::VERSION.start_with?('0.')
+                          [{ only: :show }]
+                        else
+                          ["state_action_category", { only: :show }]
+                        end
+    action_item(*action_item_args) do
     link_to "Posts", admin_category_posts_path(resource)
   end
 end


### PR DESCRIPTION
@macfanatic  : I forgot to put the Active Admin version fix for the dummy app in the specs. It's the same changes as in the DSL file.